### PR TITLE
chore(codeowners): make Platform owner of infra files [PLAT-7118]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @teamsnap/ish
+* @teamsnap/platform


### PR DESCRIPTION
## Summary

Implements [PLAT-7118](https://teamsnap.atlassian.net/browse/PLAT-7118) for this repo (still referenced the legacy `ish`/`cse` team). Opened as a **draft**.

## Transformation
- `@teamsnap/ish` -> `@teamsnap/platform`; `@teamsnap/cse` -> `@teamsnap/staffeng-web-backend` (deduped).
- `infra/**` and `.teamsnap/**` -> add `@teamsnap/platform` as co-owner (existing owners kept).
- `.github/**` -> `@teamsnap/platform` + `@teamsnap/quality` + primary team(s).
- `CODEOWNERS` -> owned by `@teamsnap/platform` alongside primary team(s). File kept at repo root.

## Access validity
Push access for every owner is granted in companion PR [terraform-deployments#2476](https://github.com/teamsnap/terraform-deployments/pull/2476). Owners are not honored by GitHub until that PR is merged & applied.

Generated with Claude Code

[PLAT-7118]: https://teamsnap.atlassian.net/browse/PLAT-7118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ